### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/net.osgiliath.poms/net.osgiliath.pom.repositories/net.osgiliath.pom.reporting/net.osgiliath.pom.plugins/net.osgiliath.pom.dependency-management/pom.xml
+++ b/net.osgiliath.poms/net.osgiliath.pom.repositories/net.osgiliath.pom.reporting/net.osgiliath.pom.plugins/net.osgiliath.pom.dependency-management/pom.xml
@@ -1501,7 +1501,7 @@
 		<com.google.guava_guava.version>13.0.1</com.google.guava_guava.version>
 		<commons-beanutils_commons-beanutils.version>1.9.2</commons-beanutils_commons-beanutils.version>
 		<commons-codec_commons-codec.version>1.9</commons-codec_commons-codec.version>
-		<commons-collections_commons-collections.version>3.2.1</commons-collections_commons-collections.version>
+		<commons-collections_commons-collections.version>3.2.2</commons-collections_commons-collections.version>
 		<commons-io_commons-io.version>2.4</commons-io_commons-io.version>
 		<commons-lang_commons-lang.version>2.6</commons-lang_commons-lang.version>
 		<commons-logging_commons-logging.version>1.2</commons-logging_commons-logging.version>


### PR DESCRIPTION

Version 3.2.1 has a CVSS 10.0 vulnerability. That is the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/